### PR TITLE
feat: Add Alauda release automation and documentation

### DIFF
--- a/.github/workflows/alauda-auto-tag.yaml
+++ b/.github/workflows/alauda-auto-tag.yaml
@@ -1,0 +1,87 @@
+name: Auto Tag for Alauda
+
+on:
+  push:
+    branches:
+      - 'alauda-v*'
+
+permissions:
+  contents: write  # create tags and releases
+  packages: write  # upload packages
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch all tags
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version and tag prefix
+        id: extract
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          echo "Branch: $BRANCH_NAME"
+
+          PREFIX="${BRANCH_NAME%%-*}"  # alauda
+          BASE_VERSION="${BRANCH_NAME#${PREFIX}-}"  # v0.62.1
+
+          VERSION_NO_V="${BASE_VERSION#v}"              # 0.62.1
+          MAJOR=$(echo "$VERSION_NO_V" | cut -d. -f1)
+          MINOR=$(echo "$VERSION_NO_V" | cut -d. -f2)
+          PATCH=$(echo "$VERSION_NO_V" | cut -d. -f3)
+
+          echo "MAJOR: $MAJOR, MINOR: $MINOR, PATCH: $PATCH"
+
+          # PATCH + 1
+          NEXT_PATCH=$((PATCH + 1))
+          echo "NEXT_PATCH=$NEXT_PATCH"
+
+          NEXT_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}"   # v0.62.2
+          echo "NEXT_VERSION=$NEXT_VERSION"
+
+          TAG_PREFIX="${NEXT_VERSION}-${PREFIX}"  # v0.62.2-alauda
+          echo "TAG_PREFIX=$TAG_PREFIX"
+
+          echo "prefix=$PREFIX" >> $GITHUB_OUTPUT
+          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
+          echo "tag_prefix=$TAG_PREFIX" >> $GITHUB_OUTPUT
+
+      - name: Find latest tag with this prefix
+        id: latest
+        run: |
+          TAG_PREFIX="${{ steps.extract.outputs.tag_prefix }}"
+          echo "Looking for tags with prefix: $TAG_PREFIX"
+
+          EXISTING_TAGS=$(git tag --list "${TAG_PREFIX}-*" | sort -V)
+          echo "Existing tags: $EXISTING_TAGS"
+
+          MAX_INDEX=-1
+          for tag in $EXISTING_TAGS; do
+            NUM=${tag##*-}
+            if [[ "$NUM" =~ ^[0-9]+$ && "$NUM" -gt "$MAX_INDEX" ]]; then
+              MAX_INDEX=$NUM
+            fi
+          done
+
+          NEW_INDEX=$((MAX_INDEX + 1))
+          NEW_TAG="${TAG_PREFIX}-${NEW_INDEX}"
+
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
+      - name: Create and push new tag
+        run: |
+          NEW_TAG="${{ steps.latest.outputs.new_tag }}"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+  release-alauda:
+    name: Release Alauda
+    needs: [tag]
+    uses: ./.github/workflows/reusable-release-alauda.yaml

--- a/.github/workflows/release-alauda.yaml
+++ b/.github/workflows/release-alauda.yaml
@@ -1,0 +1,16 @@
+name: Release Alauda
+
+on:
+  push:
+    tags:
+      - "v*-alauda-*"
+  workflow_dispatch:
+
+permissions:
+  contents: write  # create releases
+  packages: write  # upload packages
+
+jobs:
+  release-alauda:
+    name: Release Alauda
+    uses: ./.github/workflows/reusable-release-alauda.yaml

--- a/.github/workflows/reusable-release-alauda.yaml
+++ b/.github/workflows/reusable-release-alauda.yaml
@@ -1,0 +1,33 @@
+name: Release Alauda
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    name: alauda-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.1.0
+          args: release -f=.goreleaser-alauda.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser-alauda.yml
+++ b/.goreleaser-alauda.yml
@@ -1,0 +1,58 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: golangci-lint
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -w -s -extldflags '-static'
+    main: .
+    binary: alauda-golangci-lint
+
+archives:
+  - id: archive
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    This release is intended for use only as part of the Alauda product suite.
+    It is not recommended for use by individuals or teams outside of Alauda.
+    Any consequences arising from its use are the sole responsibility of the user.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,64 @@
+# Golangci-lint alauda Branch Development Guide
+
+## Background
+
+Previously, golangci-lint was used as a general-purpose CLI across multiple plugins, each needing to fix vulnerabilities in golangci-lint independently.
+
+To avoid duplicated efforts, we forked the [golangci-lint](https://github.com/golangci/golangci-lint) repository and maintain it through branches named `alauda-vx.xx.xx`.
+
+We use [renovate](https://gitlab-ce.alauda.cn/devops/tech-research/renovate/-/blob/main/docs/quick-start/0002-quick-start.md) to automatically fix vulnerabilities in corresponding versions.
+
+## Repository Structure
+
+Based on the original code, the following content has been added:
+
+- [alauda-auto-tag.yaml](./.github/workflows/alauda-auto-tag.yaml): Automatically tags and triggers goreleaser when a PR is merged into the `alauda-vx.xx.xx` branch
+- [release-alauda.yaml](./.github/workflows/release-alauda.yaml): Supports triggering goreleaser manually or upon tag updates (this pipeline isn't triggered when tags are created by actions due to GitHub Actions design limitations)
+- [reusable-release-alauda.yaml](./.github/workflows/reusable-release-alauda.yaml): Executes goreleaser to create a release
+- [scan-alauda.yaml](.github/workflows/scan-alauda.yaml): Runs trivy vulnerability scans (`rootfs` scans for Go binaries)
+- [.goreleaser-alauda.yml](.goreleaser-alauda.yml): Configuration file for releasing alauda versions
+
+## Special Modifications
+
+None at present
+
+## Pipelines
+
+### Triggered on PR Submission
+
+- [tests.yaml](.github/workflows/tests.yaml): Official testing pipeline including unit tests, integration tests, etc.
+
+### Triggered on Merge to alauda-vx.xx.xx Branch
+
+- [alauda-auto-tag.yaml](.github/workflows/alauda-auto-tag.yaml): Automatically tags and triggers goreleaser
+- [reusable-release-alauda.yaml](.github/workflows/reusable-release-alauda.yaml): Executes goreleaser to create a release (triggered by `alauda-auto-tag.yaml`)
+
+### Scheduled or Manual Triggering
+
+- [scan-alauda.yaml](.github/workflows/scan-alauda.yaml): Runs trivy vulnerability scans (`rootfs` scans for Go binaries)
+
+### Others
+
+Other officially maintained pipelines remain unchanged; some irrelevant pipelines have been disabled on the Actions page.
+
+## Renovate Vulnerability Fix Mechanism
+
+The renovate configuration file is [renovate.json](https://github.com/AlaudaDevops/trivy/blob/main/renovate.json)
+
+1. renovate detects vulnerabilities in the branch and submits a PR for fixes
+2. Tests run automatically on the PR
+3. After all tests pass, renovate automatically merges the PR
+4. After the branch updates, an action automatically tags the commit (e.g., v0.62.1-alauda-0, with patch version and last digit incremented)
+5. goreleaser automatically publishes a release based on the tag
+
+## Maintenance Plan
+
+When upgrading to a new version, follow these steps:
+
+1. Create an alauda branch from the corresponding tag, e.g., tag `v0.62.1` corresponds to branch `alauda-v0.62.1`
+2. Cherry-pick previous alauda branch changes onto the new branch and push
+
+Renovate automatic fix mechanism:
+1. After renovate submits a PR, pipelines run automatically; if all tests pass, the PR will be merged automatically
+2. After merging into the `alauda-v0.62.1` branch, goreleaser will automatically create a `v0.62.2-alauda-0` release (note: not `v0.62.1-alauda-0`, because upgrading the version allows renovate to recognize it)
+3. renovate configured in other plugins will automatically fetch artifacts from the release according to its configuration


### PR DESCRIPTION
- Add GitHub Actions workflows for automated tagging and releases
- Add GoReleaser configuration for Alauda builds
- Add development documentation for branch maintenance

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
