### PR TITLE
feat: enhance Alauda release with version generation and build flags

### DIFF
--- a/.github/workflows/reusable-release-alauda.yaml
+++ b/.github/workflows/reusable-release-alauda.yaml
@@ -24,6 +24,13 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Generate Version
+        id: generate_version
+        run: |
+          # remove "alauda-" prefix
+          GENERATED_VERSION=$(echo "${{ github.ref_name }}" | sed 's/alauda-//')
+          echo "GENERATED_VERSION=$GENERATED_VERSION" >> $GITHUB_OUTPUT
+
       - name: Set up GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -31,3 +38,4 @@ jobs:
           args: release -f=.goreleaser-alauda.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GENERATED_VERSION: ${{ steps.generate_version.outputs.GENERATED_VERSION }}

--- a/.goreleaser-alauda.yml
+++ b/.goreleaser-alauda.yml
@@ -22,8 +22,9 @@ builds:
     goarch:
       - amd64
       - arm64
-    ldflags:
-      - -w -s -extldflags '-static'
+    flags:
+      - -trimpath
+    ldflags: -s -w -X main.version={{.Env.GENERATED_VERSION}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     main: ./cmd/golangci-lint/
     binary: alauda-golangci-lint
 


### PR DESCRIPTION
Add version generation step to remove 'alauda-' prefix from tag names and configure ldflags for proper version embedding in binaries.

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
