### PR TITLE
chore: ugprade golangci-lint to Go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.23.11
+go 1.24.5
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0


### PR DESCRIPTION
Used to fix the following error:
- the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.5)

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
