### PR TITLE
chore: update Go version to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/v2
 
-go 1.24.0
+go 1.25.5
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0


### PR DESCRIPTION
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
