### PR TITLE
chore: upgrade Go version to 1.26

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.25'
+      GO_VERSION: '1.26'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   update-gha-assets:

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -13,7 +13,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.25'
+      GO_VERSION: '1.26'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -30,7 +30,7 @@ jobs:
 
   # We already run the current golangci-lint in tests, but here we test
   # our GitHub action with the latest stable golangci-lint.
-  # **Important**: The v1 version of the action on GitHub does not support golang 1.25, so it needs to be disabled.
+  # **Important**: The v1 version of the action on GitHub does not support golang 1.26, so it needs to be disabled.
   golangci-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.25'
+      GO_VERSION: '1.26'
       CHOCOLATEY_VERSION: 2.2.0
     steps:
       # temporary workaround for an error in free disk space action

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.25.5
+go 1.26.0
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0

--- a/scripts/gen_github_action_config/go.mod
+++ b/scripts/gen_github_action_config/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/scripts/gen_github_action_config
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7


### PR DESCRIPTION
- Update go.mod to go 1.26.0
- Update scripts/gen_github_action_config/go.mod to go 1.26.0
- Update GO_VERSION in all GitHub Actions workflows from 1.25 to 1.26

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
