### PR TITLE
chore: bump Go version to 1.26.1

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -15,7 +15,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.26.0'
+      GO_VERSION: '1.26.1'
       HUGO_VERSION: 0.148.1
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.26.0'
+  GO_VERSION: '1.26.1'
 
 jobs:
   update-gha-assets:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.26.0'
+  GO_VERSION: '1.26.1'
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -13,7 +13,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.26.0'
+      GO_VERSION: '1.26.1'
       HUGO_VERSION: 0.148.1
       CGO_ENABLED: 0
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,7 +10,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.26.0'
+  GO_VERSION: '1.26.1'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -65,7 +65,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
         golang:
-          - '1.26.0'
+          - '1.26.1'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.26.0'
+      GO_VERSION: '1.26.1'
       CHOCOLATEY_VERSION: 2.2.0
     steps:
       # temporary workaround for an error in free disk space action

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,3 +1,3 @@
 module github.com/golangci/docs
 
-go 1.26.0
+go 1.26.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/v2
 
-go 1.26.0
+go 1.26.1
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0

--- a/pkg/golinters/arangolint/testdata/go.mod
+++ b/pkg/golinters/arangolint/testdata/go.mod
@@ -1,6 +1,6 @@
 module arangolint
 
-go 1.26.0
+go 1.26.1
 
 require github.com/arangodb/go-driver/v2 v2.1.5
 

--- a/pkg/golinters/exptostd/testdata/go.mod
+++ b/pkg/golinters/exptostd/testdata/go.mod
@@ -1,5 +1,5 @@
 module exptostd
 
-go 1.26.0
+go 1.26.1
 
 require golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6

--- a/pkg/golinters/ginkgolinter/testdata/go.mod
+++ b/pkg/golinters/ginkgolinter/testdata/go.mod
@@ -1,6 +1,6 @@
 module ginkgolinter
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2

--- a/pkg/golinters/gomodguard/testdata/go.mod
+++ b/pkg/golinters/gomodguard/testdata/go.mod
@@ -1,6 +1,6 @@
 module gomodguard
 
-go 1.26.0
+go 1.26.1
 
 require (
 	golang.org/x/mod v0.24.0

--- a/pkg/golinters/loggercheck/testdata/go.mod
+++ b/pkg/golinters/loggercheck/testdata/go.mod
@@ -1,6 +1,6 @@
 module loggercheck
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/go-kit/log v0.2.1

--- a/pkg/golinters/protogetter/testdata/go.mod
+++ b/pkg/golinters/protogetter/testdata/go.mod
@@ -1,6 +1,6 @@
 module protogetter
 
-go 1.26.0
+go 1.26.1
 
 require (
 	google.golang.org/grpc v1.76.0

--- a/pkg/golinters/spancheck/testdata/go.mod
+++ b/pkg/golinters/spancheck/testdata/go.mod
@@ -1,6 +1,6 @@
 module spancheck
 
-go 1.26.0
+go 1.26.1
 
 require (
 	go.opentelemetry.io/otel v1.38.0

--- a/pkg/golinters/zerologlint/testdata/go.mod
+++ b/pkg/golinters/zerologlint/testdata/go.mod
@@ -1,6 +1,6 @@
 module zerologlint
 
-go 1.26.0
+go 1.26.1
 
 require github.com/rs/zerolog v1.34.0
 

--- a/scripts/gen_github_action_config/go.mod
+++ b/scripts/gen_github_action_config/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/v2/scripts/gen_github_action_config
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7


### PR DESCRIPTION
- Update GO_VERSION in all GitHub Actions workflow files
- Update go directive in go.mod and docs/go.mod
- Update go directive in all testdata go.mod files
- Update go directive in scripts/gen_github_action_config/go.mod

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
