### PR TITLE
chore: upgrade Go version to 1.26.1

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.26'
+      GO_VERSION: '1.26.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.26'
+  GO_VERSION: '1.26.1'
 
 jobs:
   update-gha-assets:

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -13,7 +13,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.26'
+      GO_VERSION: '1.26.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.26'
+  GO_VERSION: '1.26.1'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -46,17 +46,6 @@ jobs:
       #   uses: golangci/golangci-lint-action@v6.5.0
       #   with:
       #     version: latest
-
-  tests-on-windows:
-    needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
-      - name: Run tests
-        run: make.exe test
 
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.26'
+      GO_VERSION: '1.26.1'
       CHOCOLATEY_VERSION: 2.2.0
     steps:
       # temporary workaround for an error in free disk space action

--- a/build/buildx-alpine.Dockerfile
+++ b/build/buildx-alpine.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.21
-FROM golang:1.26-alpine
+FROM golang:1.26.1-alpine
 
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go

--- a/build/buildx.Dockerfile
+++ b/build/buildx.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.21
-FROM golang:1.26
+FROM golang:1.26.1
 
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.26.0
+go 1.26.1
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0

--- a/scripts/gen_github_action_config/go.mod
+++ b/scripts/gen_github_action_config/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/scripts/gen_github_action_config
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7


### PR DESCRIPTION
- Update GO_VERSION in all GitHub Actions workflow files
- Update Dockerfile base images to golang:1.26.1 and golang:1.26.1-alpine
- Update go directive in go.mod and scripts/gen_github_action_config/go.mod

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
